### PR TITLE
Correcting variable as it should be a list rather than string

### DIFF
--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -8,7 +8,7 @@ In your [Terraform configuration](https://learn.hashicorp.com/terraform/getting-
 
 ```hcl
 module "rubrik_aws_cloud_cluster" {
-  source  = "rubrikinc/aws-rubrik-cloud-cluster/module"
+  source  = "rubrikinc/rubrik-cloud-cluster/aws"
 
   aws_vpc_security_group_ids = ["sg-0fc82928bd323ed3qq"]
   aws_subnet_id              = "subnet-0278a40b29e52203a"

--- a/main.tf
+++ b/main.tf
@@ -42,7 +42,7 @@ resource "aws_instance" "rubrik_cluster" {
   count                  = "${var.number_of_nodes}"
   instance_type          = "${var.aws_instance_type}"
   ami                    = "${data.aws_ami.rubrik_cloud_cluster.id}"
-  vpc_security_group_ids = "${var.aws_vpc_security_group_ids}"
+  vpc_security_group_ids = ["${var.aws_vpc_security_group_ids}"]
   subnet_id              = "${var.aws_subnet_id}"
 
   tags {


### PR DESCRIPTION
# Description

Following [usage](https://github.com/rubrikinc/terraform-aws-rubrik-cloud-cluster#usage) example TF plan fails with following errors:
```
Error: module.rubrik_aws_cloud_cluster.aws_instance.rubrik_cluster[0]: vpc_security_group_ids: should be a list
Error: module.rubrik_aws_cloud_cluster.aws_instance.rubrik_cluster[1]: vpc_security_group_ids: should be a list
Error: module.rubrik_aws_cloud_cluster.aws_instance.rubrik_cluster[2]: vpc_security_group_ids: should be a list
Error: module.rubrik_aws_cloud_cluster.aws_instance.rubrik_cluster[3]: vpc_security_group_ids: should be a list
```
This is due to missing brackets in https://github.com/rubrikinc/terraform-aws-rubrik-cloud-cluster/blob/master/main.tf#L45

## Motivation and Context

Trying to deploy rubrik cluster using Terraform 0.11.14

## How Has This Been Tested?
- I have deployed the cluster successfully with fix proposed in this PR using my fork.

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)

