### PR TITLE
Use AWS provided ntp servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,21 +28,21 @@ module "rubrik_aws_cloud_cluster" {
 
 ### Inputs
 
-| Name                        | Description                                                                                                            |  Type  |     Default     | Required |
-|-----------------------------|------------------------------------------------------------------------------------------------------------------------|:------:|:---------------:|:--------:|
-| aws_instance_type           | The type of instance to use as the Cloud Cluster nodes.                                                                | string |    m5.xlarge    |    no    |
-| aws_disable_api_termination | If true, enables EC2 Instance Termination Protection                                                                   |  bool  |       true      |    no    |
-| aws_vpc_security_group_ids  | A list of security group IDs to associate with the Cloud Cluster.                                                      |  list  |                 |    yes   |
-| aws_subnet_id               | The VPC Subnet ID to launch the Cloud Cluster in.                                                                      | string |                 |    yes   |
-| number_of_nodes             | The total number of nodes in the Cloud Cluster                                                                         |   int  |        4        |    no    |
-| cluster_disk_size           | The size of each the three data disks in each node.                                                                    | string |       1024      |    no    |
-| cluster_name                | Unique name to assign to the Rubrik cluster. Also used for EC2 instance name tag. For example, rubrik-1, rubrik-2 etc. | string |                 |    yes   |
-| admin_email                 | The Rubrik cluster sends messages for the admin account to this email address.                                         | string |                 |    yes   |
-| admin_password              | Password for the Cloud Cluster admin account.                                                                          | string | RubrikGoForward |    no    |
-| dns_search_domain           | List of search domains that the DNS Service will use to resolve hostnames that are not fully qualified.                |  list  |                 |    yes   |
-| dns_name_servers            | List of the IPv4 addresses of the DNS servers.                                                                         |  list  |                 |    yes   |
-| ntp_servers                 | List of FQDN or IPv4 addresses of a network time protocol (NTP) server(s)                                              |  list  |   ["8.8.8.8"]   |          |
-| timeout                     | The number of seconds to wait to establish a connection the Rubrik cluster before returning a timeout error.           |   int  |        15       |    no    |
+| Name                        | Description                                                                                                            |  Type  |     Default           | Required |
+|-----------------------------|------------------------------------------------------------------------------------------------------------------------|:------:|:---------------------:|:--------:|
+| aws_instance_type           | The type of instance to use as the Cloud Cluster nodes.                                                                | string |    m5.xlarge          |    no    |
+| aws_disable_api_termination | If true, enables EC2 Instance Termination Protection                                                                   |  bool  |       true            |    no    |
+| aws_vpc_security_group_ids  | A list of security group IDs to associate with the Cloud Cluster.                                                      |  list  |                       |    yes   |
+| aws_subnet_id               | The VPC Subnet ID to launch the Cloud Cluster in.                                                                      | string |                       |    yes   |
+| number_of_nodes             | The total number of nodes in the Cloud Cluster                                                                         |   int  |        4              |    no    |
+| cluster_disk_size           | The size of each the three data disks in each node.                                                                    | string |       1024            |    no    |
+| cluster_name                | Unique name to assign to the Rubrik cluster. Also used for EC2 instance name tag. For example, rubrik-1, rubrik-2 etc. | string |                       |    yes   |
+| admin_email                 | The Rubrik cluster sends messages for the admin account to this email address.                                         | string |                       |    yes   |
+| admin_password              | Password for the Cloud Cluster admin account.                                                                          | string | RubrikGoForward       |    no    |
+| dns_search_domain           | List of search domains that the DNS Service will use to resolve hostnames that are not fully qualified.                |  list  |                       |    yes   |
+| dns_name_servers            | List of the IPv4 addresses of the DNS servers.                                                                         |  list  |                       |    yes   |
+| ntp_servers                 | List of FQDN or IPv4 addresses of a network time protocol (NTP) server(s)                                              |  list  | ["169.254.169.123"]   |          |
+| timeout                     | The number of seconds to wait to establish a connection the Rubrik cluster before returning a timeout error.           |   int  |        15             |    no    |
 
 ## Prerequisites
 

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -8,7 +8,7 @@ In your [Terraform configuration](https://learn.hashicorp.com/terraform/getting-
 
 ```hcl
 module "rubrik_aws_cloud_cluster" {
-  source  = "rubrikinc/aws-rubrik-cloud-cluster/module"
+  source  = "rubrikinc/rubrik-cloud-cluster/aws"
 
   aws_vpc_security_group_ids = ["sg-0fc82928bd323ed3qq"]
   aws_subnet_id              = "subnet-0278a40b29e52203a"

--- a/main.tf
+++ b/main.tf
@@ -42,7 +42,7 @@ resource "aws_instance" "rubrik_cluster" {
   count                  = "${var.number_of_nodes}"
   instance_type          = "${var.aws_instance_type}"
   ami                    = "${data.aws_ami.rubrik_cloud_cluster.id}"
-  vpc_security_group_ids = "${var.aws_vpc_security_group_ids}"
+  vpc_security_group_ids = ["${var.aws_vpc_security_group_ids}"]
   subnet_id              = "${var.aws_subnet_id}"
 
   tags {

--- a/variables.tf
+++ b/variables.tf
@@ -53,7 +53,7 @@ variable "dns_name_servers" {
 
 variable "ntp_servers" {
   description = "List of FQDN or IPv4 addresses of a network time protocol (NTP) server(s)"
-  default     = ["8.8.8.8"]
+  default     = ["169.254.169.123"]
 }
 
 variable "timeout" {


### PR DESCRIPTION
# Description

Use AWS provided ntp servers

## Motivation and Context

We dont always want to use public NTP servers.
AWS provides solution for this by allowing to use their own NTP server.
https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/set-time.html
`The Amazon Time Sync Service is available through NTP at the 169.254.169.123 IP address for any instance running in a VPC.`
## How Has This Been Tested?

Deployed cluster using `169.254.169.123` as entry for `NTP Servers` during bootstrap proceess.
Confirmed status suing `ntp_status` after bootstrap process has been completed.

```
rubrik-i03fe5e8 >> ntp_status
rubrik-i03fe5e8 | success | rc=0 >>
Tue Jul 30 13:00:30 UTC 2019
     remote           refid      st t when poll reach   delay   offset  jitter
==============================================================================
 10.249.240.50   .INIT.          16 s    -   64    0    0.000    0.000   0.000
 10.249.240.25   .INIT.          16 s    -   64    0    0.000    0.000   0.000
*169.254.169.123 169.254.169.122  3 u   21   64  177    0.116    2.548   3.433

rubrik-i03fe5e8 | success | rc=0 >>
Tue Jul 30 13:00:30 UTC 2019
     remote           refid      st t when poll reach   delay   offset  jitter
==============================================================================
 10.249.240.50   .INIT.          16 u    -   64    0    0.000    0.000   0.000
 10.249.240.25   .INIT.          16 u    -   64    0    0.000    0.000   0.000

rubrik-i03fe5e8 | success | rc=0 >>
Tue Jul 30 13:00:30 UTC 2019
     remote           refid      st t when poll reach   delay   offset  jitter
==============================================================================
 10.249.240.50   .INIT.          16 s    -   64    0    0.000    0.000   0.000
 10.249.240.25   .INIT.          16 s    -   64    0    0.000    0.000   0.000
*169.254.169.123 169.254.169.122  3 u   25   64  177    0.117   -0.523   0.058

rubrik-i03fe5e8 | success | rc=0 >>
Tue Jul 30 13:00:30 UTC 2019
     remote           refid      st t when poll reach   delay   offset  jitter
==============================================================================
 10.249.240.50   .INIT.          16 u    -   64    0    0.000    0.000   0.000
 10.249.240.25   .INIT.          16 u    -   64    0    0.000    0.000   0.000
```
## Types of changes
- [x] Enhancement 

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [x ] My code follows the code style of this project.
- [x ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x ] I have read the **[CONTRIBUTION](/CONTRIBUTING.md)** document.
- [ ] I have updated the CHANGELOG file accordingly for the version that this merge modifies.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
